### PR TITLE
SEOULDATA-72 [FEATURE] 지도에서 행사 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,13 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.4'
 }
 
+bootJar {
+    enabled = false
+}
+jar {
+    enabled = true
+}
+
 allprojects {
     group = 'com.seouldata'
     version = '0.0.1'
@@ -15,6 +22,12 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
 
     sourceCompatibility = '17'
+
+    configurations {
+        compileOnly {
+            extendsFrom annotationProcessor
+        }
+    }
 
     repositories {
         mavenCentral()
@@ -53,11 +66,21 @@ subprojects {
         // swagger
         implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+        // querydsl
+        implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+        annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+        annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+        annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
         // test
         testImplementation('org.springframework.boot:spring-boot-starter-test') {
             exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
         }
         testImplementation("org.assertj:assertj-core:3.22.0")
 
+    }
+
+    clean {
+        delete file('src/main/generated')
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,5 +1,5 @@
 bootJar {
-    enabled = true
+    enabled = false
 }
 jar {
     enabled = true

--- a/common/src/main/java/com/seouldata/common/config/JpaConfig.java
+++ b/common/src/main/java/com/seouldata/common/config/JpaConfig.java
@@ -1,6 +1,10 @@
 package com.seouldata.common.config;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
@@ -10,4 +14,13 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EnableJpaAuditing
 @EntityScan(basePackages = "com.seouldata")
 public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
 }

--- a/fest/build.gradle
+++ b/fest/build.gradle
@@ -1,7 +1,7 @@
 
 
 bootJar {
-	enabled = true
+	enabled = false
 }
 jar {
 	enabled = true

--- a/fest/src/main/java/com/seouldata/fest/FestApplication.java
+++ b/fest/src/main/java/com/seouldata/fest/FestApplication.java
@@ -3,11 +3,13 @@ package com.seouldata.fest;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @EnableFeignClients(basePackages = {"com.seouldata.fest.domain.fest.client"})
 @SpringBootApplication
+@Import({com.seouldata.common.config.JpaConfig.class})
 public class FestApplication {
 
 	public static void main(String[] args) {

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidCodeName.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidCodeName.java
@@ -1,0 +1,17 @@
+package com.seouldata.fest.domain.fest.annotation.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidCodeNameValidator.class)
+@Documented
+public @interface ValidCodeName {
+    String message() default "Invalid code name";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidCodeNameValidator.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidCodeNameValidator.java
@@ -1,0 +1,36 @@
+package com.seouldata.fest.domain.fest.annotation.validation;
+
+import com.seouldata.fest.domain.fest.entity.Codename;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.List;
+
+public class ValidCodeNameValidator implements ConstraintValidator<ValidCodeName, List<String>> {
+
+    @Override
+    public void initialize(ValidCodeName constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(List<String> value, ConstraintValidatorContext context) {
+        if (value == null || value.isEmpty()) {
+            return true; // null 또는 빈 목록은 유효하다고 가정합니다.
+        }
+
+        for (String codeName : value) {
+            boolean isValidCodeName = false;
+            for (Codename codename : Codename.values()) {
+                if (codename.getCodeType().equals(codeName)) {
+                    isValidCodeName = true;
+                    break;
+                }
+            }
+            if (!isValidCodeName) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidFilterValues.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidFilterValues.java
@@ -1,0 +1,16 @@
+package com.seouldata.fest.domain.fest.annotation.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {ValidFilterValuesValidator.class})
+@Documented
+public @interface ValidFilterValues {
+    String message() default "Invalid filter value";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidFilterValuesValidator.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidFilterValuesValidator.java
@@ -1,0 +1,37 @@
+package com.seouldata.fest.domain.fest.annotation.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ValidFilterValuesValidator implements ConstraintValidator<ValidFilterValues, List<String>> {
+
+    private static final Set<String> VALID_FILTER_VALUES = new HashSet<>();
+
+    static {
+        VALID_FILTER_VALUES.add("year");
+        VALID_FILTER_VALUES.add("codename");
+    }
+
+    @Override
+    public void initialize(ValidFilterValues constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(List<String> value, ConstraintValidatorContext context) {
+
+        if(value == null || value.isEmpty()) {
+            return true;
+        }
+
+        for (String val : value) {
+            if (!VALID_FILTER_VALUES.contains(val.toLowerCase())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidYear.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidYear.java
@@ -1,0 +1,17 @@
+package com.seouldata.fest.domain.fest.annotation.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = ValidYearValidator.class)
+@Documented
+public @interface ValidYear {
+    String message() default "Year should be between 2023 and current year";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}
+

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidYearValidator.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/annotation/validation/ValidYearValidator.java
@@ -1,0 +1,30 @@
+package com.seouldata.fest.domain.fest.annotation.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.time.Year;
+import java.util.List;
+
+public class ValidYearValidator implements ConstraintValidator<ValidYear, List<Integer>> {
+
+    @Override
+    public void initialize(ValidYear constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(List<Integer> value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        int currentYear = Year.now().getValue();
+
+        for(int year : value) {
+            if(year < 2023 || year > currentYear) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/controller/FestController.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/controller/FestController.java
@@ -1,14 +1,21 @@
 package com.seouldata.fest.domain.fest.controller;
 
 import com.seouldata.common.response.EnvelopResponse;
+import com.seouldata.fest.domain.fest.annotation.validation.ValidCodeName;
+import com.seouldata.fest.domain.fest.annotation.validation.ValidFilterValues;
+import com.seouldata.fest.domain.fest.annotation.validation.ValidYear;
 import com.seouldata.fest.domain.fest.dto.request.AddFestReq;
+import com.seouldata.fest.domain.fest.dto.request.FindFestByCriteriaReq;
 import com.seouldata.fest.domain.fest.dto.request.ModifyFestReq;
 import com.seouldata.fest.domain.fest.service.FestService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -56,6 +63,28 @@ public class FestController {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(EnvelopResponse.builder().data(festService.getFestByCode(memSeq, codename)).code(HttpStatus.OK.value()).build());
+    }
+
+    @GetMapping("/search/map")
+    public ResponseEntity<EnvelopResponse> getFestByCriteria(@RequestHeader("memSeq") Long memSeq,
+                                                             @RequestParam("lot") @NotNull double lot,
+                                                             @RequestParam("lat") @NotNull double lat,
+                                                             @RequestParam("distance") @NotNull int distance,
+                                                             @ValidFilterValues @RequestParam(value = "filter", required = false) List<String> filter,
+                                                             @ValidYear @RequestParam(value = "year", required = false) List<Integer> year,
+                                                             @ValidCodeName @RequestParam(value = "codeName", required = false) List<String> codeName) {
+
+        FindFestByCriteriaReq findFestByCriteriaReq = FindFestByCriteriaReq.builder()
+                .lot(lot)
+                .lat(lat)
+                .distance(distance)
+                .filter(filter)
+                .year(year)
+                .codename(codeName)
+                .build();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(EnvelopResponse.builder().data(festService.getFestByCriteria(memSeq, findFestByCriteriaReq)).code(HttpStatus.OK.value()).build());
     }
 
 }

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/dto/request/FindFestByCriteriaReq.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/dto/request/FindFestByCriteriaReq.java
@@ -1,0 +1,36 @@
+package com.seouldata.fest.domain.fest.dto.request;
+
+import com.seouldata.fest.domain.fest.annotation.validation.ValidCodeName;
+import com.seouldata.fest.domain.fest.annotation.validation.ValidFilterValues;
+import com.seouldata.fest.domain.fest.annotation.validation.ValidYear;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class FindFestByCriteriaReq {
+
+    @NotNull
+    private double lot;
+
+    @NotNull
+    private double lat;
+
+    @NotNull
+    private int distance;
+
+    @ValidFilterValues
+    private List<String> filter;
+
+    @ValidYear
+    private List<Integer> year;
+
+    @ValidCodeName
+    private List<String> codename;
+
+}

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/dto/response/GetFestByCriteriaResDto.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/dto/response/GetFestByCriteriaResDto.java
@@ -1,0 +1,27 @@
+package com.seouldata.fest.domain.fest.dto.response;
+
+import lombok.*;
+
+@ToString
+@Getter
+public class GetFestByCriteriaResDto {
+
+    private Long festSeq;
+
+    private String title;
+
+    private Double lot;
+
+    private Double lat;
+
+    @Setter
+    private boolean heart;
+
+    public GetFestByCriteriaResDto(Long festSeq, String title, Double lot, Double lat) {
+        this.festSeq = festSeq;
+        this.title = title;
+        this.lot = lot;
+        this.lat = lat;
+    }
+
+}

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/entity/Codename.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/entity/Codename.java
@@ -1,5 +1,7 @@
 package com.seouldata.fest.domain.fest.entity;
 
+import lombok.Getter;
+
 public enum Codename {
 
     MUSICAL_OPERA("뮤지컬/오페라", 1),
@@ -19,6 +21,7 @@ public enum Codename {
     FEST_ETC("축제-기타", 15),
     FEST_NATURE_LANDSCAPE("축제-자연/경관", 16);
 
+    @Getter
     private final String codeType;
     private final int codeNum;
 

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepository.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepository.java
@@ -1,5 +1,7 @@
 package com.seouldata.fest.domain.fest.repository;
 
+import com.seouldata.fest.domain.fest.dto.request.FindFestByCriteriaReq;
+import com.seouldata.fest.domain.fest.dto.response.GetFestByCriteriaResDto;
 import com.seouldata.fest.domain.fest.entity.Fest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface FestRepository extends JpaRepository<Fest, Long> {
+public interface FestRepository extends JpaRepository<Fest, Long>, FestRepositoryCustom {
 
     int countAllByIsPublic(boolean isPublic);
 
@@ -21,5 +23,7 @@ public interface FestRepository extends JpaRepository<Fest, Long> {
 
     @Query(value = "select f from Fest f where f.codename = :codename and f.isDeleted = false")
     List<Fest> findFestByCodenameAndDeletedIsFalse(@Param("codename") int codename);
+
+    List<GetFestByCriteriaResDto> findAllByCriteria(Long memSeq, FindFestByCriteriaReq findFestByCriteriaReq);
 
 }

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepositoryCustom.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.seouldata.fest.domain.fest.repository;
+
+import com.seouldata.fest.domain.fest.dto.request.FindFestByCriteriaReq;
+import com.seouldata.fest.domain.fest.dto.response.GetFestByCriteriaResDto;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FestRepositoryCustom {
+
+    List<GetFestByCriteriaResDto> findAllByCriteria(Long memSeq, FindFestByCriteriaReq findFestByCriteriaReq);
+
+}
+

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepositoryCustomImpl.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepositoryCustomImpl.java
@@ -1,0 +1,102 @@
+package com.seouldata.fest.domain.fest.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seouldata.fest.domain.fest.dto.request.FindFestByCriteriaReq;
+import com.seouldata.fest.domain.fest.dto.response.GetFestByCriteriaResDto;
+import com.seouldata.fest.domain.fest.entity.Codename;
+import com.seouldata.fest.domain.fest.entity.Fest;
+import com.seouldata.fest.domain.fest.entity.QFest;
+import com.seouldata.fest.domain.heart.repository.HeartRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class FestRepositoryCustomImpl implements FestRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QFest fest = QFest.fest;
+    private final HeartRepository heartRepository;
+
+    @Override
+    public List<GetFestByCriteriaResDto> findAllByCriteria(Long memSeq, FindFestByCriteriaReq findFestByCriteriaReq) {
+
+        BooleanExpression criteriaBuilder = fest.isDeleted.isFalse();
+
+        if (findFestByCriteriaReq.getYear() != null) {
+            List<Integer> years = findFestByCriteriaReq.getYear();
+            BooleanExpression yearCondition = null;
+
+            for (Integer year : years) {
+                BooleanExpression yearExp = fest.startDate.year().eq(year)
+                        .or(fest.endDate.year().eq(year));
+
+                if (yearCondition == null) {
+                    yearCondition = yearExp;
+                } else {
+                    yearCondition = yearCondition.or(yearExp);
+                }
+            }
+
+            criteriaBuilder = criteriaBuilder.and(yearCondition);
+        }
+
+        if (findFestByCriteriaReq.getCodename() != null) {
+            List<String> codeNames = findFestByCriteriaReq.getCodename();
+            BooleanExpression codeNameCondition = null;
+
+            for (String codeName : codeNames) {
+                int codeNum = Codename.getCodeNum(codeName);
+                if (codeNum != -1) {
+                    BooleanExpression codeNameExp = fest.codename.eq(codeNum);
+
+                    if (codeNameCondition == null) {
+                        codeNameCondition = codeNameExp;
+                    } else {
+                        codeNameCondition = codeNameCondition.or(codeNameExp);
+                    }
+                }
+            }
+
+            if (codeNameCondition != null) {
+                criteriaBuilder = criteriaBuilder.and(codeNameCondition);
+            }
+        }
+
+        double latitude = findFestByCriteriaReq.getLat();
+        double longitude = findFestByCriteriaReq.getLot();
+        double distanceInKm = findFestByCriteriaReq.getDistance();
+
+        NumberExpression<Double> distanceExpression = Expressions.numberTemplate(Double.class,
+                "st_distance_sphere(point(lat, lot), point({0}, {1}))", longitude, latitude);
+
+        criteriaBuilder = criteriaBuilder.and(distanceExpression.loe(distanceInKm * 1000));
+
+        List<GetFestByCriteriaResDto> result = queryFactory
+                .select(Projections.constructor(GetFestByCriteriaResDto.class,
+                        fest.festSeq,
+                        fest.title,
+                        fest.lot,
+                        fest.lat))
+                .from(fest)
+                .where(criteriaBuilder)
+                .fetch();
+
+        for (GetFestByCriteriaResDto dto : result) {
+            Fest f = queryFactory.selectFrom(fest)
+                    .where(fest.festSeq.eq(dto.getFestSeq()))
+                    .fetchOne();
+
+            boolean heartExists = heartRepository.existsByFestAndAndMemSeq(f, memSeq);
+
+            dto.setHeart(heartExists);
+        }
+
+        return result;
+    }
+
+}

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/service/FestService.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/service/FestService.java
@@ -1,8 +1,10 @@
 package com.seouldata.fest.domain.fest.service;
 
 import com.seouldata.fest.domain.fest.dto.request.AddFestReq;
+import com.seouldata.fest.domain.fest.dto.request.FindFestByCriteriaReq;
 import com.seouldata.fest.domain.fest.dto.request.ModifyFestReq;
 import com.seouldata.fest.domain.fest.dto.response.GetFestDetailRes;
+import com.seouldata.fest.domain.fest.dto.response.GetFestByCriteriaResDto;
 import com.seouldata.fest.domain.fest.dto.response.GetFestRes;
 
 import java.util.List;
@@ -20,5 +22,7 @@ public interface FestService {
     GetFestDetailRes getFestDetail(Long memSeq, Long festSeq);
 
     List<GetFestRes> getFestByCode(Long memSeq, String codename);
+
+    List<GetFestByCriteriaResDto> getFestByCriteria(Long memSeq, FindFestByCriteriaReq findFestByCriteriaReq);
 
 }

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/service/FestServiceImpl.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/service/FestServiceImpl.java
@@ -4,11 +4,9 @@ import com.seouldata.common.exception.BusinessException;
 import com.seouldata.common.exception.ErrorCode;
 import com.seouldata.fest.domain.fest.client.OpenApiFeignClient;
 import com.seouldata.fest.domain.fest.dto.request.AddFestReq;
+import com.seouldata.fest.domain.fest.dto.request.FindFestByCriteriaReq;
 import com.seouldata.fest.domain.fest.dto.request.ModifyFestReq;
-import com.seouldata.fest.domain.fest.dto.response.GetFestDetailRes;
-import com.seouldata.fest.domain.fest.dto.response.GetFestRes;
-import com.seouldata.fest.domain.fest.dto.response.GetFestResDto;
-import com.seouldata.fest.domain.fest.dto.response.TagRes;
+import com.seouldata.fest.domain.fest.dto.response.*;
 import com.seouldata.fest.domain.fest.entity.Codename;
 import com.seouldata.fest.domain.fest.entity.Fest;
 import com.seouldata.fest.domain.fest.repository.FestRepository;
@@ -247,6 +245,14 @@ public class FestServiceImpl implements FestService {
                             .build();
                 })
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<GetFestByCriteriaResDto> getFestByCriteria(Long memSeq, FindFestByCriteriaReq findFestByCriteriaReq) {
+
+        List<GetFestByCriteriaResDto> festList = festRepository.findAllByCriteria(memSeq, findFestByCriteriaReq);
+
+        return festList;
     }
 
 }

--- a/fest/src/main/java/com/seouldata/fest/domain/heart/repository/HeartRepository.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/heart/repository/HeartRepository.java
@@ -18,4 +18,6 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
     @Query(value = "select f from Heart h left join Fest f on h.fest.festSeq = f.festSeq where h.memSeq = :memSeq")
     List<Fest> findFestByMemSeq(@Param("memSeq") Long memSeq);
 
+    boolean existsByFestAndAndMemSeq(Fest fest, long memSeq);
+
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 rootProject.name = 'seouldata'
 
 include 'common'
-include 'auth'
+//include 'auth'
 include 'fest'


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-72 -> dev-fest

# 변경 사항
> QueryDSL 의존성 추가 및 환경 설정
> 지도에서 행사 조회 API 구현
