### PR TITLE
SEOULDATA-33 [FEATURE] 랜덤 닉네임 생성 API

### DIFF
--- a/auth/src/main/java/com/seouldata/auth/domain/auth/controller/AuthController.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/controller/AuthController.java
@@ -30,4 +30,13 @@ public class AuthController {
                 );
     }
 
+    @GetMapping("/nickname")
+    public ResponseEntity<EnvelopResponse> createRandomNickname() {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(EnvelopResponse.builder()
+                        .data(authService.createRandomNickname())
+                        .build()
+                );
+    }
+
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/dto/response/CreateNicknameRes.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/dto/response/CreateNicknameRes.java
@@ -1,0 +1,16 @@
+package com.seouldata.auth.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateNicknameRes {
+
+        private String nickname;
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/enums/Adjective.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/enums/Adjective.java
@@ -1,0 +1,43 @@
+package com.seouldata.auth.domain.auth.enums;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Adjective {
+
+    HAPPY ("기분 좋은"),
+    SAD ("슬픈"),
+    EXCITED ("신이 난"),
+    ANGRY ("화난"),
+    CALM ("차분한"),
+    JOYFUL ("기쁜"),
+    GLOOMY ("우울한"),
+    CONTENT ("만족스러운"),
+    ENTHUSIASTIC ("열정적인"),
+    RELAXED ("편안한"),
+    NERVOUS ("긴장하는"),
+    SURPRISED ("놀란"),
+    CONFUSED ("혼란스러운"),
+    PROUD ("자랑스러운"),
+    SCARED ("무서워하는"),
+    HOPEFUL ("희망찬"),
+    GRATEFUL ("감사한"),
+    INSECURE ("불안한"),
+    JEALOUS ("질투하는"),
+    LONELY ("외로운"),
+    DISAPPOINTED ("실망한"),
+    TIRED ("피곤한"),
+    ENERGETIC ("에너지 넘치는"),
+    AMUSED ("극도로 감탄하는"),
+    CURIOUS ("호기심 많은"),
+    RELIEVED ("안심한"),
+    ANTICIPATORY ("기대하는"),
+    AWE_STRUCK ("경탄하는"),
+    APPREHENSIVE ("걱정스러운"),
+    ;
+
+    private final String korean;
+
+    public String getKorean() { return this.korean; }
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/enums/Noun.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/enums/Noun.java
@@ -1,0 +1,44 @@
+package com.seouldata.auth.domain.auth.enums;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Noun {
+
+    DOG ("개"),
+    CAT ("고양이"),
+    MOUSE ("쥐"),
+    ELEPHANT ("코끼리"),
+    MONKEY ("원숭이"),
+    TIGER ("호랑이"),
+    LION ("사자"),
+    BEAR ("곰"),
+    DEER ("사슴"),
+    SQUIRREL ("다람쥐"),
+    RABBIT ("토끼"),
+    SNAKE ("뱀"),
+    HORSE ("말"),
+    COW ("소"),
+    PIG ("돼지"),
+    SHEEP ("양"),
+    PEACOCK ("공작새"),
+    PIGEON ("비둘기"),
+    WHALE ("고래"),
+    SHARK ("상어"),
+    DOLPHIN ("돌고래"),
+    PENGUIN ("팽귄"),
+    RHINO ("코뿔소"),
+    CROCODILE ("악어"),
+    DUCK ("오리"),
+    DINOSAUR ("공룡"),
+    CAMEL ("낙타"),
+    RACCOON ("오소리"),
+    RED_PANDA ("랫서팬더"),
+    KANGAROO ("캥거루"),
+    ;
+
+    private final String korean;
+
+    public String getKorean() { return this.korean; }
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthService.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.seouldata.auth.domain.auth.service;
 
 import com.seouldata.auth.domain.auth.dto.request.JoinMemberReq;
+import com.seouldata.auth.domain.auth.dto.response.CreateNicknameRes;
 import com.seouldata.auth.domain.auth.dto.response.JoinMemberRes;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,5 +10,7 @@ import java.io.IOException;
 public interface AuthService {
 
     JoinMemberRes join(JoinMemberReq joinMemberReq, MultipartFile profile) throws IOException;
+
+    CreateNicknameRes createRandomNickname();
 
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthServiceImpl.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthServiceImpl.java
@@ -1,8 +1,11 @@
 package com.seouldata.auth.domain.auth.service;
 
 import com.seouldata.auth.domain.auth.dto.request.JoinMemberReq;
+import com.seouldata.auth.domain.auth.dto.response.CreateNicknameRes;
 import com.seouldata.auth.domain.auth.dto.response.JoinMemberRes;
 import com.seouldata.auth.domain.auth.entity.Member;
+import com.seouldata.auth.domain.auth.enums.Adjective;
+import com.seouldata.auth.domain.auth.enums.Noun;
 import com.seouldata.auth.domain.auth.repository.AuthRepository;
 import com.seouldata.auth.global.exception.AuthErrorCode;
 import com.seouldata.auth.global.exception.AuthException;
@@ -50,8 +53,27 @@ public class AuthServiceImpl implements AuthService {
                 .build();
     }
 
+    @Override
+    public CreateNicknameRes createRandomNickname() {
+        Adjective adjective = Adjective.values()[getRandomNumber(Adjective.values().length)];
+        Noun noun = Noun.values()[getRandomNumber(Noun.values().length)];
+        String nickname = new StringBuilder()
+                .append(adjective.getKorean())
+                .append(" ")
+                .append(noun.getKorean())
+                .toString();
+
+        return CreateNicknameRes.builder()
+                .nickname(nickname)
+                .build();
+    }
+
     private String saveProfileImage(MultipartFile profile) throws IOException {
         return awsService.saveFile(profile);
+    }
+
+    private int getRandomNumber(int max) {
+        return (int) (Math.random() * max);
     }
 
 }


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-33 -> dev-auth

# 변경 사항
- 랜덤 닉네임 생성 API
- 형용사 하나와 명사 하나를 매칭하여 생성
