### PR TITLE
SEOULDATA-97 [FEATURE] 소유한 배지 조회 API

### DIFF
--- a/auth/src/main/java/com/seouldata/auth/domain/auth/entity/Member.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/entity/Member.java
@@ -1,5 +1,6 @@
 package com.seouldata.auth.domain.auth.entity;
 
+import com.seouldata.auth.domain.badge.entity.Own;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -7,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.util.List;
 
 @Entity
 @Table(name = "member")
@@ -43,6 +46,9 @@ public class Member {
     @ColumnDefault("false")
     @NotNull
     private Boolean notification;
+
+    @OneToMany(mappedBy = "member")
+    private List<Own> owns;
 
     @Builder
     public Member(String email, String nickname, String image, String googleId, String mbti, String token, Boolean notification) {

--- a/auth/src/main/java/com/seouldata/auth/domain/badge/controller/BadgeController.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/badge/controller/BadgeController.java
@@ -1,0 +1,30 @@
+package com.seouldata.auth.domain.badge.controller;
+
+import com.seouldata.auth.domain.badge.service.BadgeService;
+import com.seouldata.common.response.EnvelopResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/badge")
+public class BadgeController {
+
+    private final BadgeService badgeService;
+
+    @GetMapping
+    public ResponseEntity<EnvelopResponse> getAllBadges(
+            @Authorization long memberSeq
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(EnvelopResponse.builder()
+                        .data(badgeService.getAllBadges(memberSeq))
+                        .build()
+                );
+    }
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/badge/dto/response/GetAllBadgesRes.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/badge/dto/response/GetAllBadgesRes.java
@@ -1,0 +1,22 @@
+package com.seouldata.auth.domain.badge.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetAllBadgesRes {
+
+    private int seq;
+
+    private String title;
+
+    private String image;
+
+    private Boolean isOwn;
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/badge/repository/BadgeRepository.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/badge/repository/BadgeRepository.java
@@ -1,0 +1,7 @@
+package com.seouldata.auth.domain.badge.repository;
+
+import com.seouldata.auth.domain.badge.entity.Badge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/badge/service/BadgeService.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/badge/service/BadgeService.java
@@ -1,0 +1,11 @@
+package com.seouldata.auth.domain.badge.service;
+
+import com.seouldata.auth.domain.badge.dto.response.GetAllBadgesRes;
+
+import java.util.List;
+
+public interface BadgeService {
+
+    List<GetAllBadgesRes> getAllBadges(long memberSeq);
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/badge/service/BadgeServiceImpl.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/badge/service/BadgeServiceImpl.java
@@ -1,0 +1,44 @@
+package com.seouldata.auth.domain.badge.service;
+
+import com.seouldata.auth.domain.auth.repository.AuthRepository;
+import com.seouldata.auth.domain.badge.dto.response.GetAllBadgesRes;
+import com.seouldata.auth.domain.badge.entity.Badge;
+import com.seouldata.auth.domain.badge.repository.BadgeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BadgeServiceImpl implements BadgeService {
+
+    private final AuthRepository authRepository;
+    private final BadgeRepository badgeRepository;
+
+    @Override
+    public List<GetAllBadgesRes> getAllBadges(long memberSeq) {
+        List<Badge> badges = badgeRepository.findAll();
+        Set<Long> ownBadgeSeqs = authRepository.findById(memberSeq).get().getOwns().stream()
+                .map(own -> own.getBadge().getBadgeSeq())
+                .collect(Collectors.toSet());
+
+        AtomicInteger seq = new AtomicInteger();
+
+        return badges.stream()
+                .map(badge -> GetAllBadgesRes.builder()
+                        .seq(seq.incrementAndGet())
+                        .title(badge.getTitle())
+                        .image(badge.getBadgeUrl())
+                        .isOwn(ownBadgeSeqs.contains(badge.getBadgeSeq()))
+                        .build()
+                )
+                .toList();
+    }
+
+}


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-97 -> dev-auth

# 변경 사항
- Member Entity에서 연관된 Badge 조회 속성 추가
- 소유한 배지 조회 API 구현