### PR TITLE
SEOULDATA-96 [FEATURE] 회원 MBTI 검사 결과 저장 API

### DIFF
--- a/auth/src/main/java/com/seouldata/auth/domain/auth/controller/AuthController.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.seouldata.auth.domain.auth.controller;
 
 import com.seouldata.auth.domain.auth.dto.request.JoinMemberReq;
+import com.seouldata.auth.domain.auth.dto.request.ModifyMbtiReq;
 import com.seouldata.auth.domain.auth.dto.request.ModifyNicknameReq;
 import com.seouldata.auth.domain.auth.service.AuthService;
 import com.seouldata.auth.global.annotation.Authorization;
@@ -44,7 +45,7 @@ public class AuthController {
                         .build()
                 );
     }
-  
+
     @GetMapping("/nickname/duplicate")
     public ResponseEntity<EnvelopResponse> checkNicknameDuplicate(
             @RequestParam(value = "nickname") String nickname
@@ -58,23 +59,36 @@ public class AuthController {
 
     @GetMapping("/nickname")
     public ResponseEntity<EnvelopResponse> createRandomNickname() {
-            return ResponseEntity.status(HttpStatus.OK)
-                    .body(EnvelopResponse.builder()
-                            .data(authService.createRandomNickname())
-                            .build()
-                    );
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(EnvelopResponse.builder()
+                        .data(authService.createRandomNickname())
+                        .build()
+                );
     }
 
     @GetMapping("/login/google")
-    ResponseEntity<EnvelopResponse> googleLogin(
+    public ResponseEntity<EnvelopResponse> googleLogin(
             @RequestParam(value = "googleId") String googleId
     ) {
         return ResponseEntity.status(HttpStatus.OK)
-                        .body(EnvelopResponse.builder()
-                                .data(authService.googleLogin(googleId))
-                                .build()
-                        );
+                .body(EnvelopResponse.builder()
+                        .data(authService.googleLogin(googleId))
+                        .build()
+                );
 
+    }
+
+    @PatchMapping("/mbti")
+    public ResponseEntity<EnvelopResponse> updateMbti(
+            @Authorization long memberSeq,
+            @RequestBody ModifyMbtiReq mbti
+            ) {
+        authService.modifyMbti(memberSeq, mbti);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(EnvelopResponse.builder()
+                        .build()
+                );
     }
 
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/dto/request/ModifyMbtiReq.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/dto/request/ModifyMbtiReq.java
@@ -1,0 +1,10 @@
+package com.seouldata.auth.domain.auth.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class ModifyMbtiReq {
+
+    private String mbti;
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/entity/Member.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/entity/Member.java
@@ -59,4 +59,8 @@ public class Member {
         this.nickname = nickname;
     }
 
+    public void setMbti(String mbti) {
+        this.mbti = mbti;
+    }
+
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthService.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.seouldata.auth.domain.auth.service;
 
 import com.seouldata.auth.domain.auth.dto.request.JoinMemberReq;
+import com.seouldata.auth.domain.auth.dto.request.ModifyMbtiReq;
 import com.seouldata.auth.domain.auth.dto.request.ModifyNicknameReq;
 import com.seouldata.auth.domain.auth.dto.response.CreateNicknameRes;
 import com.seouldata.auth.domain.auth.dto.response.GoogleLoginRes;
@@ -20,5 +21,7 @@ public interface AuthService {
     CreateNicknameRes createRandomNickname();
 
     GoogleLoginRes googleLogin(String googleId);
+
+    void modifyMbti(long memberSeq, ModifyMbtiReq mbti);
 
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthServiceImpl.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package com.seouldata.auth.domain.auth.service;
 
 import com.seouldata.auth.domain.auth.dto.request.JoinMemberReq;
+import com.seouldata.auth.domain.auth.dto.request.ModifyMbtiReq;
 import com.seouldata.auth.domain.auth.dto.request.ModifyNicknameReq;
 import com.seouldata.auth.domain.auth.dto.response.CreateNicknameRes;
 import com.seouldata.auth.domain.auth.dto.response.GoogleLoginRes;
@@ -75,6 +76,16 @@ public class AuthServiceImpl implements AuthService {
                 .accessToken(generateAccessToken(member.getMemSeq().toString()))
                 .refreshToken(generateRefreshToken(member.getMemSeq().toString()))
                 .build();
+    }
+
+    @Override
+    public void modifyMbti(long memberSeq, ModifyMbtiReq mbti) {
+        Member member = authRepository.findById(memberSeq)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        member.setMbti(mbti.getMbti());
+
+        authRepository.save(member);
     }
 
     @Override


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-91 -> dev-auth

# 변경 사항
- 회원의 MBTI 검사 결과 저장 API

# 추후 추가사항
- MBTI 검사 결과 글자 수, 유효성 검사
