### PR TITLE
SEOULDATA-92 [FEATURE] 회원 정보 조회 API

### DIFF
--- a/auth/src/main/java/com/seouldata/auth/domain/auth/controller/AuthController.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/controller/AuthController.java
@@ -88,4 +88,15 @@ public class AuthController {
                 );
     }
 
+    @GetMapping("/createInfo")
+    public ResponseEntity<EnvelopResponse> getReviewWriterInfo(
+            @RequestParam(value = "memSeq") long memSeq
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(EnvelopResponse.builder()
+                        .data(authService.getReviewWriterInfo(memSeq))
+                        .build()
+                );
+    }
+
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/controller/AuthController.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/controller/AuthController.java
@@ -77,4 +77,15 @@ public class AuthController {
 
     }
 
+    @GetMapping("/info")
+    public ResponseEntity<EnvelopResponse> getMemberInfo(
+            @Authorization long memberSeq
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(EnvelopResponse.builder()
+                        .data(authService.getMemberInfo(memberSeq))
+                        .build()
+                );
+    }
+
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/dto/response/GetMemberInfoRes.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/dto/response/GetMemberInfoRes.java
@@ -1,0 +1,24 @@
+package com.seouldata.auth.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetMemberInfoRes {
+
+    private String email;
+
+    private String nickname;
+
+    private String profile;
+
+    private String mbti;
+
+    private Boolean notification;
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/dto/response/GetReviewWriterInfo.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/dto/response/GetReviewWriterInfo.java
@@ -1,0 +1,18 @@
+package com.seouldata.auth.domain.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetReviewWriterInfo {
+
+    private String nickname;
+
+    private String mbti;
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthService.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthService.java
@@ -2,10 +2,7 @@ package com.seouldata.auth.domain.auth.service;
 
 import com.seouldata.auth.domain.auth.dto.request.JoinMemberReq;
 import com.seouldata.auth.domain.auth.dto.request.ModifyNicknameReq;
-import com.seouldata.auth.domain.auth.dto.response.CreateNicknameRes;
-import com.seouldata.auth.domain.auth.dto.response.GetMemberInfoRes;
-import com.seouldata.auth.domain.auth.dto.response.GoogleLoginRes;
-import com.seouldata.auth.domain.auth.dto.response.JoinMemberRes;
+import com.seouldata.auth.domain.auth.dto.response.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -23,5 +20,7 @@ public interface AuthService {
     GoogleLoginRes googleLogin(String googleId);
 
     GetMemberInfoRes getMemberInfo(long memberSeq);
+
+    GetReviewWriterInfo getReviewWriterInfo(long memberSeq);
 
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthService.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package com.seouldata.auth.domain.auth.service;
 import com.seouldata.auth.domain.auth.dto.request.JoinMemberReq;
 import com.seouldata.auth.domain.auth.dto.request.ModifyNicknameReq;
 import com.seouldata.auth.domain.auth.dto.response.CreateNicknameRes;
+import com.seouldata.auth.domain.auth.dto.response.GetMemberInfoRes;
 import com.seouldata.auth.domain.auth.dto.response.GoogleLoginRes;
 import com.seouldata.auth.domain.auth.dto.response.JoinMemberRes;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,5 +21,7 @@ public interface AuthService {
     CreateNicknameRes createRandomNickname();
 
     GoogleLoginRes googleLogin(String googleId);
+
+    GetMemberInfoRes getMemberInfo(long memberSeq);
 
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthServiceImpl.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package com.seouldata.auth.domain.auth.service;
 import com.seouldata.auth.domain.auth.dto.request.JoinMemberReq;
 import com.seouldata.auth.domain.auth.dto.request.ModifyNicknameReq;
 import com.seouldata.auth.domain.auth.dto.response.CreateNicknameRes;
+import com.seouldata.auth.domain.auth.dto.response.GetMemberInfoRes;
 import com.seouldata.auth.domain.auth.dto.response.GoogleLoginRes;
 import com.seouldata.auth.domain.auth.dto.response.JoinMemberRes;
 import com.seouldata.auth.domain.auth.entity.Member;
@@ -74,6 +75,20 @@ public class AuthServiceImpl implements AuthService {
                 .googleId(member.getGoogleId())
                 .accessToken(generateAccessToken(member.getMemSeq().toString()))
                 .refreshToken(generateRefreshToken(member.getMemSeq().toString()))
+                .build();
+    }
+
+    @Override
+    public GetMemberInfoRes getMemberInfo(long memberSeq) {
+        Member member = authRepository.findById(memberSeq)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        return GetMemberInfoRes.builder()
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .profile(member.getImage())
+                .mbti(member.getMbti())
+                .notification(member.getNotification())
                 .build();
     }
 

--- a/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthServiceImpl.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/service/AuthServiceImpl.java
@@ -2,10 +2,7 @@ package com.seouldata.auth.domain.auth.service;
 
 import com.seouldata.auth.domain.auth.dto.request.JoinMemberReq;
 import com.seouldata.auth.domain.auth.dto.request.ModifyNicknameReq;
-import com.seouldata.auth.domain.auth.dto.response.CreateNicknameRes;
-import com.seouldata.auth.domain.auth.dto.response.GetMemberInfoRes;
-import com.seouldata.auth.domain.auth.dto.response.GoogleLoginRes;
-import com.seouldata.auth.domain.auth.dto.response.JoinMemberRes;
+import com.seouldata.auth.domain.auth.dto.response.*;
 import com.seouldata.auth.domain.auth.entity.Member;
 import com.seouldata.auth.domain.auth.enums.Adjective;
 import com.seouldata.auth.domain.auth.enums.Noun;
@@ -89,6 +86,17 @@ public class AuthServiceImpl implements AuthService {
                 .profile(member.getImage())
                 .mbti(member.getMbti())
                 .notification(member.getNotification())
+                .build();
+    }
+
+    @Override
+    public GetReviewWriterInfo getReviewWriterInfo(long memberSeq) {
+        Member member = authRepository.findById(memberSeq)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        return GetReviewWriterInfo.builder()
+                .nickname(member.getNickname())
+                .mbti(member.getMbti())
                 .build();
     }
 

--- a/auth/src/main/java/com/seouldata/auth/global/config/SecurityConfig.java
+++ b/auth/src/main/java/com/seouldata/auth/global/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/member/nickname/duplicate").permitAll()
                         .requestMatchers(HttpMethod.POST, "/member").permitAll()
                         .requestMatchers(HttpMethod.PATCH, "/member/notification").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/member/createInfo").permitAll()
 
                         // 그 외 요청은 모두 인증 필요
                         .anyRequest().authenticated()


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-92 -> dev- auth

# 변경 사항
- 회원 정보 조회 관련 API 구현
- 리뷰 작성자 정보 조회 API 구현

# 추후 변경 사항
- fest module 담당자의 요청으로 token 없이 요청 중
  회원 정보를 요청하고 있으니 `permitAll` -> `hasIpAdress`로 변경할 것!!