### PR TITLE
SEOULDATA-46 [FEATURE] 검색어로 행사 조회 API 구현

### DIFF
--- a/fest/src/main/java/com/seouldata/fest/domain/fest/controller/FestController.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/controller/FestController.java
@@ -87,4 +87,11 @@ public class FestController {
                 .body(EnvelopResponse.builder().data(festService.getFestByCriteria(memSeq, findFestByCriteriaReq)).code(HttpStatus.OK.value()).build());
     }
 
+    @GetMapping
+    public ResponseEntity<EnvelopResponse> getFestList(@RequestHeader("memSeq") Long memSeq, @RequestParam("keyword") String keyword, @RequestParam("lot") double lot, @RequestParam("lat") double lat) {
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(EnvelopResponse.builder().data(festService.getFestList(memSeq, keyword, lot, lat)).code(HttpStatus.OK.value()).build());
+    }
+
 }

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepository.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepository.java
@@ -26,4 +26,8 @@ public interface FestRepository extends JpaRepository<Fest, Long>, FestRepositor
 
     List<GetFestByCriteriaResDto> findAllByCriteria(Long memSeq, FindFestByCriteriaReq findFestByCriteriaReq);
 
+    List<Fest> findByKeyword(String keyword);
+
+    List<Fest> findByKeywordAndLocation(String keyword, double lot, double lat);
+
 }

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepositoryCustom.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/repository/FestRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.seouldata.fest.domain.fest.repository;
 
 import com.seouldata.fest.domain.fest.dto.request.FindFestByCriteriaReq;
 import com.seouldata.fest.domain.fest.dto.response.GetFestByCriteriaResDto;
+import com.seouldata.fest.domain.fest.entity.Fest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,6 +11,10 @@ import java.util.List;
 public interface FestRepositoryCustom {
 
     List<GetFestByCriteriaResDto> findAllByCriteria(Long memSeq, FindFestByCriteriaReq findFestByCriteriaReq);
+
+    List<Fest> findByKeyword(String keyword);
+
+    List<Fest> findByKeywordAndLocation(String keyword, double lot, double lat);
 
 }
 

--- a/fest/src/main/java/com/seouldata/fest/domain/fest/service/FestService.java
+++ b/fest/src/main/java/com/seouldata/fest/domain/fest/service/FestService.java
@@ -25,4 +25,6 @@ public interface FestService {
 
     List<GetFestByCriteriaResDto> getFestByCriteria(Long memSeq, FindFestByCriteriaReq findFestByCriteriaReq);
 
+    List<GetFestRes> getFestList(Long memSeq, String keyword, double lot, double lat);
+
 }


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-46 -> dev-fest

# 변경 사항
- 검색어로 행사 조회 API 구현
  위도, 경도가 각각 -1, -1일 경우, 즐겨찾기가 많은 순으로 20개
  위도, 경도가 각각 -1, -1이 아닐 경우, 가까운 순, 최근 등록순으로 20개 

# 추후 수정 사항
- 성능 개선을 위해 엘라스틱 서치 도입할 것