### PR TITLE
SEOULDATA-98 [FEATURE] 닉네임 옆에 둘 배지 변경 API 구현

### DIFF
--- a/auth/src/main/java/com/seouldata/auth/domain/auth/entity/Member.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/auth/entity/Member.java
@@ -1,5 +1,6 @@
 package com.seouldata.auth.domain.auth.entity;
 
+import com.seouldata.auth.domain.badge.entity.Badge;
 import com.seouldata.auth.domain.badge.entity.Own;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -47,6 +48,10 @@ public class Member {
     @NotNull
     private Boolean notification;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @Column(name = "badge_seq")
+    private Badge badgeSeq;
+
     @OneToMany(mappedBy = "member")
     private List<Own> owns;
 
@@ -67,6 +72,10 @@ public class Member {
 
     public void setMbti(String mbti) {
         this.mbti = mbti;
+    }
+
+    public void setBadgeSeq(Badge badgeSeq) {
+        this.badgeSeq = badgeSeq;
     }
 
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/badge/controller/BadgeController.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/badge/controller/BadgeController.java
@@ -1,14 +1,13 @@
 package com.seouldata.auth.domain.badge.controller;
 
+import com.seouldata.auth.domain.badge.dto.request.UpdateBadgeReq;
 import com.seouldata.auth.domain.badge.service.BadgeService;
 import com.seouldata.auth.global.annotation.Authorization;
 import com.seouldata.common.response.EnvelopResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +23,19 @@ public class BadgeController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(EnvelopResponse.builder()
                         .data(badgeService.getAllBadges(memberSeq))
+                        .build()
+                );
+    }
+
+    @PatchMapping
+    public ResponseEntity<EnvelopResponse> updateMyBadge(
+            @Authorization long memberSeq,
+            @RequestBody UpdateBadgeReq updateMyBadgeReq
+    ) {
+        badgeService.updateMyBadge(memberSeq, updateMyBadgeReq);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(EnvelopResponse.builder()
                         .build()
                 );
     }

--- a/auth/src/main/java/com/seouldata/auth/domain/badge/dto/request/UpdateBadgeReq.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/badge/dto/request/UpdateBadgeReq.java
@@ -1,0 +1,10 @@
+package com.seouldata.auth.domain.badge.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateBadgeReq {
+
+    private int seq;
+
+}

--- a/auth/src/main/java/com/seouldata/auth/domain/badge/service/BadgeService.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/badge/service/BadgeService.java
@@ -1,5 +1,6 @@
 package com.seouldata.auth.domain.badge.service;
 
+import com.seouldata.auth.domain.badge.dto.request.UpdateBadgeReq;
 import com.seouldata.auth.domain.badge.dto.response.GetAllBadgesRes;
 
 import java.util.List;
@@ -7,5 +8,7 @@ import java.util.List;
 public interface BadgeService {
 
     List<GetAllBadgesRes> getAllBadges(long memberSeq);
+
+    void updateMyBadge(long memberSeq, UpdateBadgeReq updateMyBadgeReq);
 
 }

--- a/auth/src/main/java/com/seouldata/auth/domain/badge/service/BadgeServiceImpl.java
+++ b/auth/src/main/java/com/seouldata/auth/domain/badge/service/BadgeServiceImpl.java
@@ -1,9 +1,13 @@
 package com.seouldata.auth.domain.badge.service;
 
+import com.seouldata.auth.domain.auth.entity.Member;
 import com.seouldata.auth.domain.auth.repository.AuthRepository;
+import com.seouldata.auth.domain.badge.dto.request.UpdateBadgeReq;
 import com.seouldata.auth.domain.badge.dto.response.GetAllBadgesRes;
 import com.seouldata.auth.domain.badge.entity.Badge;
 import com.seouldata.auth.domain.badge.repository.BadgeRepository;
+import com.seouldata.auth.global.exception.AuthErrorCode;
+import com.seouldata.auth.global.exception.AuthException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -39,6 +43,17 @@ public class BadgeServiceImpl implements BadgeService {
                         .build()
                 )
                 .toList();
+    }
+
+    @Override
+    public void updateMyBadge(long memberSeq, UpdateBadgeReq updateMyBadgeReq) {
+        Member member = authRepository.findById(memberSeq)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        Badge badge = badgeRepository.findById((long) updateMyBadgeReq.getSeq())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.BADGE_NOT_FOUND));
+
+        member.setBadgeSeq(badge);
     }
 
 }

--- a/auth/src/main/java/com/seouldata/auth/global/exception/AuthErrorCode.java
+++ b/auth/src/main/java/com/seouldata/auth/global/exception/AuthErrorCode.java
@@ -12,6 +12,8 @@ public enum AuthErrorCode implements ErrorCode {
     USER_ALREADY_EXISTS(500, "이미 가입된 사용자입니다."),
 
     NICKNAME_ALREADY_EXISTS(500, "이미 사용중인 닉네임입니다."),
+
+    BADGE_NOT_FOUND(500, "뱃지를 찾을 수 없습니다.")
     ;
 
     private final int code;


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-98 -> dev-auth

# 변경 사항
- 배지가 없는 경우 예외 코드 정의
- 닉네임 옆에 둘 배지 변경 API 구현
